### PR TITLE
[BB-10699] Add configurable user query params

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,15 +70,46 @@ Using the Studio editor, you can edit the following fields:
 - survey id
 - university
 - link text
+- extra parameters
 - message
-- parameter name for userid
-
-Note: If you plan to make use of the "Param Name" field to store User ID
-data, you will need to configure your Qualtrics surveys to in turn
-collect that data on Qualtrics’ end.
 
 |image-cms-editor-1|
 |image-cms-editor-2|
+
+
+Configuration
+~~~~~~~~~~~~~
+
+Operators can configure system-wide defaults via ``XBLOCK_SETTINGS`` in
+the Django settings:
+
+.. code-block:: python
+
+    XBLOCK_SETTINGS["QualtricsSurvey"] = {
+        "DEFAULT_UNIVERSITY": "pennstate",
+        "USER_QUERY_PARAMS": {
+            "edxuid": "user_id",
+            "email": "email",
+        },
+    }
+
+``DEFAULT_UNIVERSITY``
+    The default Qualtrics subdomain for your institution. Used when the
+    per-instance university field is left blank.
+
+``USER_QUERY_PARAMS``
+    A mapping of URL parameter names to user attributes. The key is the
+    query parameter name that appears in the survey URL, and the value is
+    the user attribute to resolve. Supported attributes:
+
+    - ``user_id`` -- platform user ID (with fallback to anonymous ID)
+    - ``anonymous_id`` -- anonymous student identifier
+    - ``email`` -- primary email address
+    - ``username`` -- platform username
+
+    If ``USER_QUERY_PARAMS`` is not configured, no user parameters are
+    sent by default. To start sending user data to Qualtrics, operators
+    must explicitly configure this setting.
 
 
 Participants

--- a/qualtricssurvey/models.py
+++ b/qualtricssurvey/models.py
@@ -46,17 +46,12 @@ class QualtricsSurveyModelMixin:
     )
     extra_params = String(
         display_name=_("Extra Parameters:"),
-        default=(
-            "example_param_1=example_value_1&"
-            "example_param_2=example_value_2"
-        ),
+        default="",
         scope=Scope.settings,
         help=_(
-            "Here you can add extra parameters to include in the survey url. "
-            "you can add set of parameters and their value like:"
-            "example_param_1=example_value_1&example_param_2=example_value_2"
-            "Make sure it doesn't start with &"
-            "If blank, extra parameters are ommitted from the url."
+            "Additional query parameters to include in the survey URL. "
+            "Format: key1=value1&key2=value2. "
+            "If blank, no extra parameters are added."
         ),
     )
     survey_id = String(
@@ -70,8 +65,18 @@ class QualtricsSurveyModelMixin:
         ),
     )
     your_university = String(
-        display_name=_("Your University's Qualtrics ID:"),
-        default="pennstate",
+        display_name=_("Your University:"),
+        default="",
         scope=Scope.settings,
-        help=_("This is the id of university in Qualtrics example: pennstate"),
+        help=_(
+            "The subdomain for your university's Qualtrics account "
+            "(e.g.'stanforduniversity'). "
+            "If left blank, the system-wide default is used."
+        ),
+    )
+    # Deprecated: kept for backward compatibility with existing course data.
+    # Not included in editable_fields so it no longer appears in Studio.
+    param_name = String(
+        default='a',
+        scope=Scope.settings,
     )

--- a/qualtricssurvey/models.py
+++ b/qualtricssurvey/models.py
@@ -77,6 +77,6 @@ class QualtricsSurveyModelMixin:
     # Deprecated: kept for backward compatibility with existing course data.
     # Not included in editable_fields so it no longer appears in Studio.
     param_name = String(
-        default='a',
+        default='',
         scope=Scope.settings,
     )

--- a/qualtricssurvey/tests/test_display.py
+++ b/qualtricssurvey/tests/test_display.py
@@ -70,16 +70,32 @@ class TestRender(unittest.TestCase):
     def test_student_view_defaults(self):
         """
         Checks the default student view with no XBLOCK_SETTINGS configured.
-        Since param_name defaults to 'a' and no USER_QUERY_PARAMS is set,
-        the legacy fallback sends {param_name: anonymous_id}.
+        Since param_name defaults to '' and no USER_QUERY_PARAMS is set,
+        no user params are sent.
         """
         xblock = self.xblock
         fragment = xblock.student_view()
         content = fragment.content
         self.assertIn('Begin Survey', content)
         self.assertIn('target="_blank"', content)
-        self.assertIn('?a=anon-user-id', content)
+        self.assertNotIn('?', content)
         self.assertIn(xblock.message, content)
+
+    def test_blank_param_name_sends_nothing(self):
+        """
+        When param_name is deliberately blank and no USER_QUERY_PARAMS
+        is configured, no user params are sent. This respects a
+        deliberate opt-out of user identification.
+        """
+        xblock = mock_an_xblock(
+            field_overrides={'param_name': ''},
+        )
+
+        content = xblock.student_view().content
+
+        self.assertNotIn('edxuid=', content)
+        self.assertNotIn('anon-user-id', content)
+        self.assertNotIn('?', content)
 
     def test_student_view_with_settings(self):
         """

--- a/qualtricssurvey/tests/test_display.py
+++ b/qualtricssurvey/tests/test_display.py
@@ -11,7 +11,7 @@ from xblock.field_data import DictFieldData
 from qualtricssurvey.xblocks import QualtricsSurvey
 
 
-def mock_an_xblock(field_overrides=None, user_service=None):
+def mock_an_xblock(field_overrides=None, user_service=None, xblock_settings=None):
     """
     Create and return an instance of the XBlock
     """
@@ -23,6 +23,9 @@ def mock_an_xblock(field_overrides=None, user_service=None):
     i18n_service.ugettext.side_effect = lambda text: text
     i18n_service.gettext.side_effect = lambda text: text
 
+    settings_service = mock.Mock()
+    settings_service.get_settings_bucket.return_value = xblock_settings or {}
+
     def local_resource_url(_block, _path):
         return 'http://example.org/resource'
 
@@ -33,6 +36,8 @@ def mock_an_xblock(field_overrides=None, user_service=None):
             return user_service
         if service_name == 'i18n':
             return i18n_service
+        if service_name == 'settings':
+            return settings_service
         raise Exception('Service not available')
 
     runtime.service = mock.Mock(side_effect=service)
@@ -60,29 +65,41 @@ class TestRender(unittest.TestCase):
         self.assertNotEqual('', html)
         self.assertIn('qualtricssurvey_block', html)
 
-    def test_student_view(self):
+    def test_student_view_defaults(self):
         """
-        Checks the student view using the anonymous user fallback when
-        runtime user services are unavailable.
+        Checks the default student view with no XBLOCK_SETTINGS configured.
+        Since param_name defaults to 'a' and no USER_QUERY_PARAMS is set,
+        the legacy fallback sends {param_name: anonymous_id}.
         """
         xblock = self.xblock
         fragment = xblock.student_view()
         content = fragment.content
         self.assertIn('Begin Survey', content)
         self.assertIn('target="_blank"', content)
-        self.assertIn(
-            'href="https://pennstate.qualtrics.com/jfe/form/Enter your survey '
-            'ID here.?',
-            content
-        )
-        self.assertIn('example_param_1=example_value_1', content)
-        self.assertIn('example_param_2=example_value_2', content)
-        self.assertIn('?edxuid=anon-user-id', content)
+        self.assertIn('?a=anon-user-id', content)
         self.assertIn(xblock.message, content)
+
+    def test_student_view_with_settings(self):
+        """
+        When USER_QUERY_PARAMS is configured in XBLOCK_SETTINGS,
+        uses the configured mapping instead of legacy param_name.
+        """
+        xblock = mock_an_xblock(
+            xblock_settings={
+                'USER_QUERY_PARAMS': {
+                    'edxuid': 'user_id',
+                    'email': 'email',
+                },
+            },
+        )
+        content = xblock.student_view().content
+        self.assertIn('?edxuid=anon-user-id', content)
+        self.assertNotIn('a=', content)
 
     def test_student_view_with_user_service(self):
         """
-        Checks the student view when the runtime provides user information.
+        Checks the student view when the runtime provides user information
+        and USER_QUERY_PARAMS is configured.
         """
         user = mock.Mock()
         user.user_id = None
@@ -95,6 +112,12 @@ class TestRender(unittest.TestCase):
         xblock = mock_an_xblock(
             field_overrides={'extra_params': 'foo=bar&baz='},
             user_service=user_service,
+            xblock_settings={
+                'USER_QUERY_PARAMS': {
+                    'edxuid': 'user_id',
+                    'email': 'email',
+                },
+            },
         )
 
         content = xblock.student_view().content
@@ -103,6 +126,139 @@ class TestRender(unittest.TestCase):
         self.assertIn('&amp;email=user%40example.com', content)
         self.assertIn('&amp;foo=bar', content)
         self.assertIn('&amp;baz=', content)
+
+    def test_custom_user_query_params(self):
+        """
+        Checks that USER_QUERY_PARAMS from XBLOCK_SETTINGS controls which
+        user attributes are sent and under what parameter names.
+        """
+        user = mock.Mock()
+        user.user_id = '99'
+        user.opt_attrs = {'edx-platform.username': 'jdoe'}
+        user.emails = ['j@example.com']
+        user_service = mock.Mock()
+        user_service.get_current_user.return_value = user
+        xblock = mock_an_xblock(
+            user_service=user_service,
+            xblock_settings={
+                'USER_QUERY_PARAMS': {
+                    'uid': 'user_id',
+                    'uname': 'username',
+                },
+            },
+        )
+
+        content = xblock.student_view().content
+
+        self.assertIn('uid=99', content)
+        self.assertIn('uname=jdoe', content)
+        self.assertNotIn('email=', content)  # not in the mapping
+        self.assertNotIn('edxuid=', content)  # overridden
+
+    def test_empty_user_query_params(self):
+        """
+        Setting USER_QUERY_PARAMS to empty dict disables all user params.
+        """
+        xblock = mock_an_xblock(
+            xblock_settings={'USER_QUERY_PARAMS': {}},
+        )
+
+        content = xblock.student_view().content
+
+        self.assertNotIn('edxuid=', content)
+        self.assertNotIn('email=', content)
+        self.assertNotIn('?', content)
+
+    def test_unknown_attribute_key_skipped(self):
+        """
+        An unrecognized attribute key in USER_QUERY_PARAMS is silently skipped.
+        """
+        xblock = mock_an_xblock(
+            xblock_settings={
+                'USER_QUERY_PARAMS': {
+                    'x': 'nonexistent_attribute',
+                    'edxuid': 'user_id',
+                },
+            },
+        )
+
+        content = xblock.student_view().content
+
+        self.assertNotIn('x=', content)
+        self.assertIn('edxuid=anon-user-id', content)
+
+    def test_param_name_backward_compat(self):
+        """
+        When no USER_QUERY_PARAMS is configured and the legacy param_name
+        field has a value, fall back to {param_name: anonymous_id}.
+        """
+        xblock = mock_an_xblock(
+            field_overrides={'param_name': 'a'},
+        )
+
+        content = xblock.student_view().content
+
+        self.assertIn('?a=anon-user-id', content)
+        self.assertNotIn('edxuid=', content)
+
+    def test_param_name_overridden_by_settings(self):
+        """
+        When USER_QUERY_PARAMS is set in XBLOCK_SETTINGS, param_name is
+        ignored even if it has a value.
+        """
+        xblock = mock_an_xblock(
+            field_overrides={'param_name': 'a'},
+            xblock_settings={
+                'USER_QUERY_PARAMS': {'edxuid': 'user_id'},
+            },
+        )
+
+        content = xblock.student_view().content
+
+        self.assertIn('edxuid=anon-user-id', content)
+        self.assertNotIn('a=', content)
+
+    def test_university_from_settings_fallback(self):
+        """
+        When your_university field is blank, falls back to DEFAULT_UNIVERSITY
+        from XBLOCK_SETTINGS.
+        """
+        xblock = mock_an_xblock(
+            xblock_settings={'DEFAULT_UNIVERSITY': 'mit'},
+        )
+
+        content = xblock.student_view().content
+
+        self.assertIn('https://mit.qualtrics.com', content)
+
+    def test_university_field_takes_precedence(self):
+        """
+        When your_university field has a value, it takes precedence over
+        DEFAULT_UNIVERSITY from XBLOCK_SETTINGS.
+        """
+        xblock = mock_an_xblock(
+            field_overrides={'your_university': 'stanford'},
+            xblock_settings={'DEFAULT_UNIVERSITY': 'mit'},
+        )
+
+        content = xblock.student_view().content
+
+        self.assertIn('https://stanford.qualtrics.com', content)
+        self.assertNotIn('mit', content)
+
+    def test_extra_params(self):
+        """
+        Checks that extra_params are appended to the survey URL.
+        """
+        xblock = mock_an_xblock(
+            field_overrides={'extra_params': 'course=CS101&term=fall'},
+            xblock_settings={'USER_QUERY_PARAMS': {}},
+        )
+
+        content = xblock.student_view().content
+
+        self.assertIn('course=CS101', content)
+        self.assertIn('term=fall', content)
 
     def test_custom_message(self):
         """

--- a/qualtricssurvey/tests/test_display.py
+++ b/qualtricssurvey/tests/test_display.py
@@ -11,7 +11,9 @@ from xblock.field_data import DictFieldData
 from qualtricssurvey.xblocks import QualtricsSurvey
 
 
-def mock_an_xblock(field_overrides=None, user_service=None, xblock_settings=None):
+def mock_an_xblock(
+    field_overrides=None, user_service=None, xblock_settings=None,
+):
     """
     Create and return an instance of the XBlock
     """

--- a/qualtricssurvey/views.py
+++ b/qualtricssurvey/views.py
@@ -15,12 +15,6 @@ except ModuleNotFoundError:
 from .mixins.fragment import XBlockFragmentBuilderMixin
 
 
-DEFAULT_USER_QUERY_PARAMS = {
-    'edxuid': 'user_id',
-    'email': 'email',
-}
-
-
 def _resolve_user_id(xblock, user, runtime):
     """Resolve the platform user ID with fallbacks."""
     if user:
@@ -112,13 +106,15 @@ class QualtricsSurveyViewMixin(
 
         user = user_service.get_current_user() if user_service else None
 
-        if 'USER_QUERY_PARAMS' not in settings and self.param_name:
-            # fallback: use the old param_name -> anonymous_id behavior
+        if 'USER_QUERY_PARAMS' in settings:
+            param_map = settings['USER_QUERY_PARAMS']
+        elif self.param_name:
+            # Legacy fallback: use the old param_name -> anonymous_id
             param_map = {self.param_name: 'anonymous_id'}
         else:
-            param_map = settings.get(
-                'USER_QUERY_PARAMS', DEFAULT_USER_QUERY_PARAMS,
-            )
+            # No settings configured and param_name is blank, send
+            # nothing.
+            param_map = {}
 
         for url_param_name, attribute_key in param_map.items():
             resolver = USER_ATTRIBUTE_RESOLVERS.get(attribute_key)

--- a/qualtricssurvey/views.py
+++ b/qualtricssurvey/views.py
@@ -30,7 +30,7 @@ def _resolve_user_id(xblock, user, runtime):
     return _resolve_anonymous_id(xblock, user, runtime)
 
 
-def _resolve_anonymous_id(xblock, user, runtime):
+def _resolve_anonymous_id(xblock, _user, runtime):
     """Resolve the anonymous student ID."""
     return (
         getattr(runtime, 'anonymous_student_id', None)
@@ -41,12 +41,12 @@ def _resolve_anonymous_id(xblock, user, runtime):
     )
 
 
-def _resolve_email(xblock, user, runtime):
+def _resolve_email(_xblock, user, _runtime):
     """Resolve the primary email address."""
     return user.emails[0] if user and user.emails else None
 
 
-def _resolve_username(xblock, user, runtime):
+def _resolve_username(_xblock, user, _runtime):
     """Resolve the platform username."""
     return user.opt_attrs.get('edx-platform.username') if user else None
 
@@ -116,7 +116,9 @@ class QualtricsSurveyViewMixin(
             # fallback: use the old param_name -> anonymous_id behavior
             param_map = {self.param_name: 'anonymous_id'}
         else:
-            param_map = settings.get('USER_QUERY_PARAMS', DEFAULT_USER_QUERY_PARAMS)
+            param_map = settings.get(
+                'USER_QUERY_PARAMS', DEFAULT_USER_QUERY_PARAMS,
+            )
 
         for url_param_name, attribute_key in param_map.items():
             resolver = USER_ATTRIBUTE_RESOLVERS.get(attribute_key)

--- a/qualtricssurvey/views.py
+++ b/qualtricssurvey/views.py
@@ -15,6 +15,50 @@ except ModuleNotFoundError:
 from .mixins.fragment import XBlockFragmentBuilderMixin
 
 
+DEFAULT_USER_QUERY_PARAMS = {
+    'edxuid': 'user_id',
+    'email': 'email',
+}
+
+
+def _resolve_user_id(xblock, user, runtime):
+    """Resolve the platform user ID with fallbacks."""
+    if user:
+        user_id = user.user_id or user.opt_attrs.get('edx-platform.user_id')
+        if user_id:
+            return user_id
+    return _resolve_anonymous_id(xblock, user, runtime)
+
+
+def _resolve_anonymous_id(xblock, user, runtime):
+    """Resolve the anonymous student ID."""
+    return (
+        getattr(runtime, 'anonymous_student_id', None)
+        or getattr(
+            getattr(xblock, 'xmodule_runtime', None),
+            'anonymous_student_id', None,
+        )
+    )
+
+
+def _resolve_email(xblock, user, runtime):
+    """Resolve the primary email address."""
+    return user.emails[0] if user and user.emails else None
+
+
+def _resolve_username(xblock, user, runtime):
+    """Resolve the platform username."""
+    return user.opt_attrs.get('edx-platform.username') if user else None
+
+
+USER_ATTRIBUTE_RESOLVERS = {
+    'user_id': _resolve_user_id,
+    'anonymous_id': _resolve_anonymous_id,
+    'email': _resolve_email,
+    'username': _resolve_username,
+}
+
+
 class QualtricsSurveyViewMixin(
         XBlockFragmentBuilderMixin,
         StudioEditableXBlockMixin,
@@ -32,22 +76,27 @@ class QualtricsSurveyViewMixin(
         """
         context = context or {}
         context = dict(context)
-        query_params = self._user_query_params()
+        settings = self.get_xblock_settings(default={})
+        query_params = self._user_query_params(settings)
         query_params.extend(self._extra_query_params())
         query_string = ''
         if query_params:
             query_string = f"?{urlencode(query_params, doseq=True)}"
+        university = (
+            self.your_university
+            or settings.get('DEFAULT_UNIVERSITY', '')
+        )
         context.update({
             'xblock_id': str(self.scope_ids.usage_id),
             'survey_id': self.survey_id,
-            'your_university': self.your_university,
+            'your_university': university,
             'link_text': self.link_text,
             'query_string': query_string,
             'message': self.message,
         })
         return context
 
-    def _user_query_params(self):
+    def _user_query_params(self, settings):
         """
         Return query parameters derived from the current user.
         """
@@ -63,30 +112,19 @@ class QualtricsSurveyViewMixin(
 
         user = user_service.get_current_user() if user_service else None
 
-        opt_attrs = getattr(user, 'opt_attrs', {}) if user else {}
-        user_id = getattr(user, 'user_id', None)
-        if not user_id and hasattr(opt_attrs, 'get'):
-            user_id = opt_attrs.get('edx-platform.user_id')
+        if 'USER_QUERY_PARAMS' not in settings and self.param_name:
+            # fallback: use the old param_name -> anonymous_id behavior
+            param_map = {self.param_name: 'anonymous_id'}
+        else:
+            param_map = settings.get('USER_QUERY_PARAMS', DEFAULT_USER_QUERY_PARAMS)
 
-        emails = getattr(user, 'emails', []) if user else []
-        primary_email = emails[0] if emails else None
-
-        if not user_id:
-            anonymous_id = getattr(runtime, 'anonymous_student_id', None)
-            if not anonymous_id:
-                xmodule_runtime = getattr(self, 'xmodule_runtime', None)
-                anonymous_id = getattr(
-                    xmodule_runtime,
-                    'anonymous_student_id',
-                    None,
-                )
-            user_id = anonymous_id
-
-        if user_id:
-            params.append(('edxuid', user_id))
-
-        if primary_email:
-            params.append(('email', primary_email))
+        for url_param_name, attribute_key in param_map.items():
+            resolver = USER_ATTRIBUTE_RESOLVERS.get(attribute_key)
+            if not resolver:
+                continue
+            value = resolver(self, user, runtime)
+            if value:
+                params.append((url_param_name, value))
 
         return params
 

--- a/qualtricssurvey/xblocks.py
+++ b/qualtricssurvey/xblocks.py
@@ -3,6 +3,7 @@ This is the core logic for the XBlock
 """
 
 from xblock.core import XBlock
+from xblock.utils.settings import XBlockWithSettingsMixin
 
 from .mixins.scenario import XBlockWorkbenchMixin
 from .models import QualtricsSurveyModelMixin
@@ -11,12 +12,16 @@ from .views import QualtricsSurveyViewMixin
 
 @XBlock.needs('i18n')
 @XBlock.wants('user')
+@XBlock.wants('settings')
 class QualtricsSurvey(
         QualtricsSurveyModelMixin,
         QualtricsSurveyViewMixin,
+        XBlockWithSettingsMixin,
         XBlockWorkbenchMixin,
         XBlock,
 ):
     """
     A Qualtrics survey XBlock.
     """
+
+    block_settings_key = 'QualtricsSurvey'


### PR DESCRIPTION
## Overview
 This PR makes Penn state's customizations that were added in BB-10053, configurable so that these changes can be upstreamed. The custom values are configurable via the `XBLOCK_SETTINGS` as shown below:
 
 ```
XBLOCK_SETTINGS["QualtricsSurvey"] = {
    "DEFAULT_UNIVERSITY": "pennstate",
    "USER_QUERY_PARAMS": {
        "edxuid": "user_id",
        "email": "email",
    },
}
```
Without this configuration, the XBlock falls back to the legacy `param_name` behavior for backward compatibility.
 
 ## Supporting Information
 
 OpenCraft Internal Jira task: BB-10699
 
 ## Testing Instructions
1. Deploy this branch along with the `XBLOCK_SETTING` shown above.
2. Verify survey URLs contain correct `edxuid` and `email` params.